### PR TITLE
chore: Revert CachyOS tweaks, set esync nofile limit & tweak PCI latency

### DIFF
--- a/config/common/shared/services.yml
+++ b/config/common/shared/services.yml
@@ -3,3 +3,4 @@ system:
   enabled:
     - realtime-entsk
     - realtime-setup
+    - pci-latency

--- a/config/files/shared/bin/pci-latency
+++ b/config/files/shared/bin/pci-latency
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# This script is designed to improve the performance and reduce audio latency
+# for sound cards by setting the PCI latency timer to an optimal value of 80
+# cycles. It also resets the default value of the latency timer for other PCI
+# devices, which can help prevent devices with high default latency timers from
+# causing gaps in sound.
+
+sudo -s -- <<EOF
+
+# Reset the latency timer for all PCI devices
+setpci -v -s '*:*' latency_timer=20
+setpci -v -s '0:0' latency_timer=0
+
+# Set latency timer for all sound cards
+setpci -v -d "*:*:04xx" latency_timer=80
+EOF

--- a/config/files/shared/etc/modprobe.d/nvidia.conf
+++ b/config/files/shared/etc/modprobe.d/nvidia.conf
@@ -1,2 +1,0 @@
-options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0 NVreg_DynamicPowerManagement=0x02
-options nvidia_drm modeset=1 fbdev=1

--- a/config/files/shared/etc/security/limits.d/99-audio.conf
+++ b/config/files/shared/etc/security/limits.d/99-audio.conf
@@ -1,2 +1,0 @@
-@audio - rtprio 99
-@audio - memlock unlimited

--- a/config/files/shared/etc/security/limits.d/99-esync.conf
+++ b/config/files/shared/etc/security/limits.d/99-esync.conf
@@ -1,1 +1,2 @@
+* soft nofile 4096
 * hard nofile 2097152

--- a/config/files/shared/etc/security/limits.d/99-realtime.conf
+++ b/config/files/shared/etc/security/limits.d/99-realtime.conf
@@ -1,2 +1,0 @@
-@realtime - rtprio 99
-@realtime - memlock unlimited

--- a/config/files/shared/etc/systemd/system/rtkit-daemon.service.d/override.conf
+++ b/config/files/shared/etc/systemd/system/rtkit-daemon.service.d/override.conf
@@ -1,2 +1,0 @@
-[Service]
-LogLevelMax=info

--- a/config/files/shared/etc/tmpfiles.d/optimize-interruptfreq.conf
+++ b/config/files/shared/etc/tmpfiles.d/optimize-interruptfreq.conf
@@ -1,4 +1,0 @@
-# Increase the highest requested RTC interrupt frequency
-# https://wiki.archlinux.org/title/Professional_audio#System_configuration
-w! /sys/class/rtc/rtc0/max_user_freq - - - - 3072
-w! /proc/sys/dev/hpet/max-user-freq  - - - - 3072

--- a/config/files/shared/etc/udev/rules.d/40-hpet-permissions.rules
+++ b/config/files/shared/etc/udev/rules.d/40-hpet-permissions.rules
@@ -1,2 +1,0 @@
-KERNEL=="rtc0", GROUP="audio"
-KERNEL=="hpet", GROUP="audio"

--- a/config/files/shared/lib/systemd/system.conf.d/esync-nolimits.conf
+++ b/config/files/shared/lib/systemd/system.conf.d/esync-nolimits.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultLimitNOFILE=4096:2097152

--- a/config/files/shared/lib/systemd/system/pci-latency.service
+++ b/config/files/shared/lib/systemd/system/pci-latency.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Adjust latency timers for PCI peripherals
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/pci-latency
+
+[Install]
+WantedBy=multi-user.target

--- a/config/files/shared/lib/systemd/user.conf.d/esync-nolimits.conf
+++ b/config/files/shared/lib/systemd/user.conf.d/esync-nolimits.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultLimitNOFILE=4096:2097152


### PR DESCRIPTION
I see that `realtime-setup` RPM is installed, which already fiddles with IRQ priorities, PAM limits & that stuff, so I removed duplicate things from CachyOS & only included PCI latency service for now.

I also made sure that nolimit tweak is applied properly through systemd also.
