### PR TITLE
refactor: use list of generated recipes from jsonnet for build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,9 @@ jobs:
             sudo apt install -y jsonnet
             mkdir config/recipes 
             RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
-            echo "Generated recipes: ${RECIPES}"
-            echo "readarray -t recipes < <(echo \"${RECIPES}\")" >> $GITHUB_OUTPUT
+            readarray -t RECIPES_ARR < <(echo \"${RECIPES}\")
+            echo "Generated recipes: ${RECIPES_ARR[*]}"
+            echo "recipes=${RECIPES_ARR[@]}" >> $GITHUB_OUTPUT
   bluebuild:
     name: Build Image
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        recipe: ${{ fromJson(needs.get-repos.outputs.recipes) }}
+        recipe: ${{ fromJson(needs.generate-recipes.outputs.recipes) }}
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,25 @@ on:  # yamllint disable-line rule:truthy
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 jobs:
+  generate-recipes:
+    name: Generate Recipes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate recipes
+        id: generate-recipes
+        shell: bash
+        run: |
+            sudo apt install -y jsonnet
+            mkdir config/recipes 
+            RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
+            echo "readarray -t recipes < <(echo \"${RECIPES}\")" >> $GITHUB_OUTPUT
   bluebuild:
     name: Build Image
     runs-on: ubuntu-latest
+    needs: generate-recipes
     permissions:
       contents: read
       packages: write
@@ -23,11 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        recipe:
-          - ".yml"
-          - "-nvidia.yml"
-          - "-gnome.yml"
-          - "-gnome-nvidia.yml"
+        recipe: ${{ needs.get-repos.outputs.recipes }}
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
@@ -40,18 +52,15 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Generate recipes
-        id: recipes_meta
-        run: |
-            sudo apt install -y jsonnet
-            mkdir config/recipes 
-            jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y
-            echo "IMAGE_NAME=$(yq '.name' config/recipes/recipe${{matrix.recipe}} )" >> $GITHUB_OUTPUT
-            echo "IMAGE_DESCRIPTION=$(yq '.description' config/recipes/recipe${{matrix.recipe}} )" >> $GITHUB_OUTPUT
-            echo "VERSION=39" >> $GITHUB_OUTPUT
-            echo "tags=$(yq '."image-version"' config/recipes/recipe${{matrix.recipe}} )" >> $GITHUB_OUTPUT
       
+      - name: Generate recipes
+        id: recipe_meta
+        run: |
+            echo "IMAGE_NAME=$(yq '.name' ${{matrix.recipe}} )" >> $GITHUB_OUTPUT
+            echo "IMAGE_DESCRIPTION=$(yq '.description' ${{matrix.recipe}} )" >> $GITHUB_OUTPUT
+            echo "VERSION=39" >> $GITHUB_OUTPUT
+            echo "tags=$(yq '."image-version"' ${{matrix.recipe}} )" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -65,9 +74,9 @@ jobs:
           images: |
             ${{ env.IMAGE_NAME }}
           labels: |
-            org.opencontainers.image.title=${{ steps.recipes_meta.outputs.IMAGE_NAME }}
-            org.opencontainers.image.version=${{ steps.recipes_meta.outputs.VERSION }}
-            org.opencontainers.image.description=${{ steps.recipes_meta.outputs.IMAGE_DESCRIPTION }}
+            org.opencontainers.image.title=${{ steps.recipe_meta.outputs.IMAGE_NAME }}
+            org.opencontainers.image.version=${{ steps.recipe_meta.outputs.VERSION }}
+            org.opencontainers.image.description=${{ steps.recipe_meta.outputs.IMAGE_DESCRIPTION }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/atomic-studio-org/Atomic-Studio/main/README.md
             io.artifacthub.package.logo-url=https://raw.githubusercontent.com/atomic-studio-org/Atomic-Studio/main/assets/studio-blob.png
 
@@ -82,7 +91,7 @@ jobs:
             tail -f /dev/null
           docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
           docker stop -t 0 blue-build-installer
-          /usr/local/bin/bluebuild template -v ./config/recipes/recipe${{matrix.recipe}} -o /tmp/Containerfile 
+          /usr/local/bin/bluebuild template -v ${{matrix.recipe}} -o /tmp/Containerfile 
 
       - name: Build
         id: build_image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,10 +69,10 @@ jobs:
       - name: Generate recipes
         id: recipe_meta
         run: |
-            echo "IMAGE_NAME=$(yq '.name' ${{matrix.recipe}} )" >> $GITHUB_OUTPUT
-            echo "IMAGE_DESCRIPTION=$(yq '.description' ${{matrix.recipe}} )" >> $GITHUB_OUTPUT
+            echo "IMAGE_NAME=$(yq '.name' ./${{matrix.recipe}} )" >> $GITHUB_OUTPUT
+            echo "IMAGE_DESCRIPTION=$(yq '.description' ./${{matrix.recipe}} )" >> $GITHUB_OUTPUT
             echo "VERSION=39" >> $GITHUB_OUTPUT
-            echo "tags=$(yq '."image-version"' ${{matrix.recipe}} )" >> $GITHUB_OUTPUT
+            echo "tags=$(yq '."image-version"' ./${{matrix.recipe}} )" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -104,7 +104,7 @@ jobs:
             tail -f /dev/null
           docker cp blue-build-installer:/out/bluebuild /usr/local/bin/bluebuild
           docker stop -t 0 blue-build-installer
-          /usr/local/bin/bluebuild template -v ${{matrix.recipe}} -o /tmp/Containerfile 
+          /usr/local/bin/bluebuild template -v ./${{matrix.recipe}} -o /tmp/Containerfile 
 
       - name: Build
         id: build_image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
             sudo apt install -y jsonnet
             mkdir config/recipes 
 
-            RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
+            RECIPES=$(jsonnet ./config/templates/recipe-std.jsonnet -m ./config/recipes -y)
 
             # newlines replaced with spaces
             echo "Generated recipes: ${RECIPES//$'\n'/ }"
@@ -66,9 +66,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
-      - name: Generate recipes
+      - name: Generate recipes (again) and get metadata
         id: recipe_meta
         run: |
+            sudo apt install -y jsonnet
+            mkdir config/recipes
+            jsonnet ./config/templates/recipe-std.jsonnet -m ./config/recipes -y
+
             echo "IMAGE_NAME=$(yq '.name' ./${{matrix.recipe}} )" >> $GITHUB_OUTPUT
             echo "IMAGE_DESCRIPTION=$(yq '.description' ./${{matrix.recipe}} )" >> $GITHUB_OUTPUT
             echo "VERSION=39" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,16 @@ jobs:
 
             RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
 
-            readarray -t RECIPES_ARR < <(echo \"${RECIPES}\")
+            # newlines replaced with spaces
+            echo "Generated recipes: ${RECIPES//$'\n'/ }"
 
-            echo "Generated recipes: ${RECIPES_ARR[*]}"
+            # adds [" to the start, adds "] to the end, and replaces newlines with "," to turn the newline-delimeted string into a JSON array
+            RECIPES_JSON_STR="[\"${RECIPES//$'\n'/\",\"}\"]"
+            echo "Generated JSON: ${RECIPES_JSON_STR}"
+            # JSON strings are the only way to dynamically generate GH build matrices
 
-            echo "recipes=(${RECIPES_ARR[*]})" >> $GITHUB_OUTPUT
+            echo "recipes='${RECIPES_JSON_STR}'" >> $GITHUB_OUTPUT
+            
   bluebuild:
     name: Build Image
     runs-on: ubuntu-latest
@@ -47,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        recipe: ${{ needs.generate-recipes.outputs.recipes }}
+        recipe: ${{ fromJson(needs.generate-recipes.outputs.recipes) }}
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,13 @@ jobs:
             # newlines replaced with spaces
             echo "Generated recipes: ${RECIPES//$'\n'/ }"
 
-            # adds [" to the start, adds "], " to the end, and replaces newlines with ",", to turn the newline-delimeted string into a JSON array
+            # adds [" to the start, adds "] to the end, and replaces newlines with "," to turn the newline-delimeted string into a JSON array
             RECIPES_JSON_STR="[\"${RECIPES//$'\n'/\",\"}\"]"
+            echo "Generated JSON: ${RECIPES_JSON_STR}"
             # JSON strings are the only way to dynamically generate GH build matrices
 
             echo "recipes=${RECIPES_JSON_STR}" >> $GITHUB_OUTPUT
+            
   bluebuild:
     name: Build Image
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,17 @@ jobs:
         run: |
             sudo apt install -y jsonnet
             mkdir config/recipes 
+
             RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
-            readarray -t RECIPES_ARR < <(echo \"${RECIPES}\")
-            echo "Generated recipes: ${RECIPES_ARR[*]}"
-            echo "recipes=(${RECIPES_ARR[*]})" >> $GITHUB_OUTPUT
+
+            # newlines replaced with spaces
+            echo "Generated recipes: ${RECIPES//$'\n'/ }"
+
+            # adds [" to the start, adds "], " to the end, and replaces newlines with ",", to turn the newline-delimeted string into a JSON array
+            RECIPES_JSON_STR="[\"${RECIPES//$'\n'/\",\"}\"]"
+            # JSON strings are the only way to dynamically generate GH build matrices
+
+            echo "recipes=${RECIPES_JSON_STR}" >> $GITHUB_OUTPUT
   bluebuild:
     name: Build Image
     runs-on: ubuntu-latest
@@ -43,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        recipe: ${{ needs.get-repos.outputs.recipes }}
+        recipe: ${{ fromJson(needs.get-repos.outputs.recipes) }}
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,14 +117,14 @@ jobs:
           context: .
           push: false 
           file: /tmp/Containerfile
-          tags: ${{env.IMAGE_REGISTRY}}/${{ steps.recipes_meta.outputs.IMAGE_NAME }}:latest
+          tags: ${{env.IMAGE_REGISTRY}}/${{ steps.recipe_meta.outputs.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Sign kernel
         uses: atomic-studio-org/kernel-signer-docker@main
         with:
-          image: ${{ env.IMAGE_REGISTRY }}/${{ steps.recipes_meta.outputs.IMAGE_NAME }}
-          imagename: ${{ steps.recipes_meta.outputs.IMAGE_NAME }}
+          image: ${{ env.IMAGE_REGISTRY }}/${{ steps.recipe_meta.outputs.IMAGE_NAME }}
+          imagename: ${{ steps.recipe_meta.outputs.IMAGE_NAME }}
           privkey: ${{ secrets.SBKEY }}
           pubkey: /usr/etc/pki/certs/atomic-studio-sbkey.der
           tags: latest 
@@ -145,7 +145,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Push To GHCR Image Registry
-        run: docker push --disable-content-trust ${{ env.IMAGE_REGISTRY }}/${{ steps.recipes_meta.outputs.IMAGE_NAME }}
+        run: docker push --disable-content-trust ${{ env.IMAGE_REGISTRY }}/${{ steps.recipe_meta.outputs.IMAGE_NAME }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.4.0
@@ -153,8 +153,8 @@ jobs:
       - name: Sign container image
         shell: bash
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ steps.recipes_meta.outputs.IMAGE_NAME }}@${{ steps.build_image.outputs.digest }}
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ steps.recipes_meta.outputs.IMAGE_NAME }}
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ steps.recipe_meta.outputs.IMAGE_NAME }}@${{ steps.build_image.outputs.digest }}
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ steps.recipe_meta.outputs.IMAGE_NAME }}
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
             readarray -t RECIPES_ARR < <(echo \"${RECIPES}\")
             echo "Generated recipes: ${RECIPES_ARR[*]}"
-            echo "recipes=${RECIPES_ARR[@]}" >> $GITHUB_OUTPUT
+            echo "recipes=(${RECIPES_ARR[*]})" >> $GITHUB_OUTPUT
   bluebuild:
     name: Build Image
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             echo "Generated JSON: ${RECIPES_JSON_STR}"
             # JSON strings are the only way to dynamically generate GH build matrices
 
-            echo "recipes=${RECIPES_JSON_STR}" >> $GITHUB_OUTPUT
+            echo "recipes='${RECIPES_JSON_STR}'" >> $GITHUB_OUTPUT
             
   bluebuild:
     name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             echo "Generated JSON: ${RECIPES_JSON_STR}"
             # JSON strings are the only way to dynamically generate GH build matrices
 
-            echo "recipes='${RECIPES_JSON_STR}'" >> $GITHUB_OUTPUT
+            echo "recipes=${RECIPES_JSON_STR}" >> $GITHUB_OUTPUT
             
   bluebuild:
     name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      recipes: ${{ steps.generate-recipes.outputs.recipes }}
     steps:
       - uses: actions/checkout@v4
       - name: Generate recipes
@@ -27,6 +29,7 @@ jobs:
             sudo apt install -y jsonnet
             mkdir config/recipes 
             RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
+            echo "Generated recipes: ${RECIPES}"
             echo "readarray -t recipes < <(echo \"${RECIPES}\")" >> $GITHUB_OUTPUT
   bluebuild:
     name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,16 +31,11 @@ jobs:
 
             RECIPES=$(jsonnet config/templates/recipe-std.jsonnet -m config/recipes -y)
 
-            # newlines replaced with spaces
-            echo "Generated recipes: ${RECIPES//$'\n'/ }"
+            readarray -t RECIPES_ARR < <(echo \"${RECIPES}\")
 
-            # adds [" to the start, adds "] to the end, and replaces newlines with "," to turn the newline-delimeted string into a JSON array
-            RECIPES_JSON_STR="[\"${RECIPES//$'\n'/\",\"}\"]"
-            echo "Generated JSON: ${RECIPES_JSON_STR}"
-            # JSON strings are the only way to dynamically generate GH build matrices
+            echo "Generated recipes: ${RECIPES_ARR[*]}"
 
-            echo "recipes='${RECIPES_JSON_STR}'" >> $GITHUB_OUTPUT
-            
+            echo "recipes=(${RECIPES_ARR[*]})" >> $GITHUB_OUTPUT
   bluebuild:
     name: Build Image
     runs-on: ubuntu-latest
@@ -52,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        recipe: ${{ fromJson(needs.generate-recipes.outputs.recipes) }}
+        recipe: ${{ needs.generate-recipes.outputs.recipes }}
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6


### PR DESCRIPTION
<!---
## Thank you for contributing to the Atomic Studio project!

Please [read the Contributor's Guide](https://github.com/atomic-studio-org/.github/CONTRIBUTING.md) before submitting a pull request.
-->

This generates the matrix of recipes to build automagically from the Jsonnet output, using GitHub Actions jobs. 

The commit history is a mess, but at least you can appreciate the struggle, and can of course squash it :)